### PR TITLE
Add a setting for users to lower the threshold for HW bitmaps

### DIFF
--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -32,4 +32,6 @@ class BasePreferences(
     fun displayProfile() = preferenceStore.getString("pref_display_profile_key", "")
 
     fun alwaysUseSSIVToDecode() = preferenceStore.getBoolean("pref_always_use_ssiv_to_decode", false)
+
+    fun fallbackForLongStrips() = preferenceStore.getBoolean("pref_fallback_for_long_strips", false)
 }

--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -2,6 +2,7 @@ package eu.kanade.domain.base
 
 import android.content.Context
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.tachiyomi.util.system.GLUtil
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.i18n.MR
@@ -33,5 +34,5 @@ class BasePreferences(
 
     fun alwaysUseSSIVToDecode() = preferenceStore.getBoolean("pref_always_use_ssiv_to_decode", false)
 
-    fun fallbackForLongStrips() = preferenceStore.getBoolean("pref_fallback_for_long_strips", false)
+    fun maxBitmapSize() = preferenceStore.getString("pref_max_bitmap_size", GLUtil.maxTextureSize.toString())
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.core.net.toUri
+import androidx.core.text.isDigitsOnly
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.base.BasePreferences
@@ -331,6 +332,10 @@ object SettingsAdvancedScreen : SearchableSettings {
                 basePreferences.displayProfile().set(uri.toString())
             }
         }
+
+        val maxBitmapSize = basePreferences.maxBitmapSize()
+        val maxBitmap by maxBitmapSize.collectAsState()
+
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_reader),
             preferenceItems = persistentListOf(
@@ -345,9 +350,27 @@ object SettingsAdvancedScreen : SearchableSettings {
                     pref = basePreferences.alwaysUseSSIVToDecode(),
                     title = stringResource(MR.strings.pref_always_use_ssiv_to_decode),
                 ),
-                Preference.PreferenceItem.SwitchPreference(
-                    pref = basePreferences.fallbackForLongStrips(),
-                    title = stringResource(MR.strings.pref_fallback_for_long_strips),
+                Preference.PreferenceItem.EditTextPreference(
+                    pref = maxBitmapSize,
+                    title = stringResource(MR.strings.pref_max_bitmap_size),
+                    subtitle = stringResource(MR.strings.pref_max_bitmap_size_summary),
+                    onValueChanged = {
+                        if (it.isDigitsOnly() && it <= maxBitmapSize.defaultValue()) {
+                            context.toast(MR.strings.pref_max_bitmap_size_success)
+                        } else {
+                            context.toast(MR.strings.pref_max_bitmap_size_error)
+                            return@EditTextPreference false
+                        }
+                        true
+                    },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_max_bitmap_size_reset),
+                    enabled = remember(maxBitmap) { maxBitmap != maxBitmapSize.defaultValue() },
+                    onClick = {
+                        maxBitmapSize.delete()
+                        context.toast(MR.strings.pref_max_bitmap_size_success)
+                    },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -345,6 +345,10 @@ object SettingsAdvancedScreen : SearchableSettings {
                     pref = basePreferences.alwaysUseSSIVToDecode(),
                     title = stringResource(MR.strings.pref_always_use_ssiv_to_decode),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = basePreferences.fallbackForLongStrips(),
+                    title = stringResource(MR.strings.pref_fallback_for_long_strips),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -50,14 +50,13 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
         decoder.recycle()
 
         check(bitmap != null) { "Failed to decode image" }
-
+     
         if (
             options.bitmapConfig == Bitmap.Config.HARDWARE &&
             maxOf(bitmap.width, bitmap.height) <= GLUtil.maxTextureSize
         ) {
             if (
-                bitmap.height*1.1 <= GLUtil.maxTextureSize &&
-                bitmap.width < 1100 || !fallbackForLongStrips
+                !fallbackForLongStrips || bitmap.width < dstWidth && bitmap.height*1.1 <= GLUtil.maxTextureSize
             ) {
                 val hwBitmap = bitmap.copy(Bitmap.Config.HARDWARE, false)
                 if (hwBitmap != null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -10,10 +10,13 @@ import coil3.decode.ImageSource
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.request.bitmapConfig
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.util.system.GLUtil
 import okio.BufferedSource
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.decoder.ImageDecoder
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 /**
  * A [Decoder] that uses built-in [ImageDecoder] to decode images that is not supported by the system.
@@ -24,6 +27,8 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
         val decoder = resources.sourceOrNull()?.use {
             ImageDecoder.newInstance(it.inputStream(), options.cropBorders, displayProfile)
         }
+
+        val fallbackForLongStrips by lazy { Injekt.get<BasePreferences>().fallbackForLongStrips().get() }
 
         check(decoder != null && decoder.width > 0 && decoder.height > 0) { "Failed to initialize decoder" }
 
@@ -50,10 +55,15 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
             options.bitmapConfig == Bitmap.Config.HARDWARE &&
             maxOf(bitmap.width, bitmap.height) <= GLUtil.maxTextureSize
         ) {
-            val hwBitmap = bitmap.copy(Bitmap.Config.HARDWARE, false)
-            if (hwBitmap != null) {
-                bitmap.recycle()
-                bitmap = hwBitmap
+            if (
+                bitmap.height*1.1 <= GLUtil.maxTextureSize &&
+                bitmap.width < 1100 || !fallbackForLongStrips
+            ) {
+                val hwBitmap = bitmap.copy(Bitmap.Config.HARDWARE, false)
+                if (hwBitmap != null) {
+                    bitmap.recycle()
+                    bitmap = hwBitmap
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -28,9 +28,9 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
             ImageDecoder.newInstance(it.inputStream(), options.cropBorders, displayProfile)
         }
 
-        val fallbackForLongStrips by lazy { Injekt.get<BasePreferences>().fallbackForLongStrips().get() }
-
         check(decoder != null && decoder.width > 0 && decoder.height > 0) { "Failed to initialize decoder" }
+
+        val fallbackForLongStrips by lazy { Injekt.get<BasePreferences>().fallbackForLongStrips().get() }
 
         val srcWidth = decoder.width
         val srcHeight = decoder.height

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -393,6 +393,7 @@
     <string name="pref_show_reading_mode_summary">Briefly show current mode when reader is opened</string>
     <string name="pref_display_profile">Custom display profile</string>
     <string name="pref_always_use_ssiv_to_decode">Always use SSIV to decode long strip images</string>
+    <string name="pref_fallback_for_long_strips">Fallback to software when loading long vertical strips</string>
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Custom brightness</string>
     <string name="pref_grayscale">Grayscale</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -393,7 +393,11 @@
     <string name="pref_show_reading_mode_summary">Briefly show current mode when reader is opened</string>
     <string name="pref_display_profile">Custom display profile</string>
     <string name="pref_always_use_ssiv_to_decode">Always use SSIV to decode long strip images</string>
-    <string name="pref_fallback_for_long_strips">Fallback to software when loading long vertical strips</string>
+    <string name="pref_max_bitmap_size">Set maximum height for HW bitmaps</string>
+    <string name="pref_max_bitmap_size_summary">Software bitmaps are used for big images</string>
+    <string name="pref_max_bitmap_size_success">Changed the maximum height for bitmaps</string>
+    <string name="pref_max_bitmap_size_error">Input a number equal or lower than default</string>
+    <string name="pref_max_bitmap_size_reset">Restore the maximum height for bitmaps</string>
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Custom brightness</string>
     <string name="pref_grayscale">Grayscale</string>


### PR DESCRIPTION
Add a user-defined alternative to maxTextureSize when deciding if a hardware bitmap can be created or not, for those cases were a texture fails despite being within the maxTexture limits. Default is still maxTextureSize so it shouldn't affect higher end devices